### PR TITLE
Fix-50 A number pad a string should from left

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,17 +32,22 @@ Object.defineProperty(String.prototype, "format", {
     __patterns__?.map((pattern, patt_index) => {
       const kargs = ALL_REGEXP.exec(pattern) || ALL_REGEXP.exec(pattern);
       const wargs = regExpBasic.exec(pattern);
+
       // Insert values (one 2 one / array / object)
-      
       const INDEX_VAR = (wargs ? wargs[REF] : kargs ? kargs[REF] : patt_index) || patt_index;
       let NATUAL_VALUE = isObject ? args_[0][INDEX_VAR] : args_[INDEX_VAR];
       let ACTUAL_VALUE = isObject ? args_[0][INDEX_VAR] : args_[INDEX_VAR];
+
       // Verify sintax/semantic
       if (ACTUAL_VALUE === null || ACTUAL_VALUE === undefined)
         throw new Error(
           `Replacement index ${INDEX_VAR} out of range for positional args tuple`
         );
       if (kargs) {
+        // If TYPE_VAR is not defined and the first argument is a number, pad a string should from left, so set TYPE_VAR to "d"
+        if (kargs[TYPE_VAR] === undefined && typeof ACTUAL_VALUE === "number") {
+          kargs[TYPE_VAR] = "d";
+        }
         const LETTER =
           (!kargs[FILL_CHAR]
             ? false
@@ -52,7 +57,9 @@ Object.defineProperty(String.prototype, "format", {
             : kargs[TYPE_VAR]) || kargs[TYPE_VAR];
         //  padronaze
         if (LETTER) {
-          const floatSize = pattern.includes(".") ? Number(kargs[FRACTION] || kargs[CROP_SIZE]) : DEFAULT_PLACE;
+          const floatSize = pattern.includes(".")
+            ? Number(kargs[FRACTION] || kargs[CROP_SIZE])
+            : DEFAULT_PLACE;
           switch (LETTER) {
             case "E":
               ACTUAL_VALUE =

--- a/tests.test.js
+++ b/tests.test.js
@@ -365,3 +365,10 @@ test("Throws on 0 argument for field {:<3}:48", () => {
     "@37032656/0  "
   );
 });
+
+// #50 from @LanceMoe
+test("A number pad a string should from left:50", () => {
+  expect("{:04},{:010},{:010},{:5}".format(8, 9, 6.4, 'Test')).toEqual(
+    "0008,0000000009,00000006.4,Test "
+  );
+});


### PR DESCRIPTION
fix: #50

### New test case
<img width="595" alt="image" src="https://github.com/jhonmart/python-format-js/assets/18505474/3a36a718-3dd1-45d6-9985-1da56318e899">

### Python result
<img width="556" alt="image" src="https://github.com/jhonmart/python-format-js/assets/18505474/59a35b95-6105-483e-94e2-2cb8c8b72c76">

### After fix
<img width="550" alt="image" src="https://github.com/jhonmart/python-format-js/assets/18505474/0a86bd58-5e6a-4c97-b212-0ddee558e0c6">
